### PR TITLE
Fix incorrect fibre channel port discovery

### DIFF
--- a/pure_powervc.py
+++ b/pure_powervc.py
@@ -83,7 +83,9 @@ class PureFCDriverPowerVC(PureFCDriver,
         hardware = current_array.list_hardware()
         for port in ports:
             for count in range(0, len(hardware)):
-                if hardware[count]['name'] == port.get('name'):
+                if hardware[count]['name'] == port.get('name') and port.get(
+                    'wwn'
+                ):
                     port_speed = self.convert_fc_port_speed(
                         hardware[count]['speed'])
                     pinfo = {


### PR DESCRIPTION
Check to ensure there is a WWN for the poor before adding it to the PwerVC database of FC ports.

Without this a dummy entry is created with None for the WWPN value, which causes a crash deeper into the PowerVC cinder manager code.